### PR TITLE
Add option to ignore foreign key checks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,8 @@ module.exports = function(options,done){
 		dropTable:false,
 		getDump:false,
 		dest:'./data.sql',
-		where: null
+		where: null,
+		ignoreKeys: true
 	}
 
 	mysql = mqNode(extend({},defaultConnection,{
@@ -131,6 +132,10 @@ module.exports = function(options,done){
 					if(options.ifNotExist) r = r.replace(/CREATE TABLE `/,'CREATE TABLE IF NOT EXISTS `');
 					if(!options.autoIncrement) r = r.replace(/AUTO_INCREMENT=\d+ /g,'');
 					resp.push(r)
+				}
+				if(options.ignoreKeys) {
+					resp.unshift('SET FOREIGN_KEY_CHECKS=0;');
+					resp.push('SET FOREIGN_KEY_CHECKS=1;');
 				}
 				callback(err,resp);
 			});

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ describe('mysql test', function() {
 	var connection = {
 		host: 'localhost',
 		user: 'root',
-		password: ''
+		password: 'mRi0oJLzZGWo'
 	};
 
 	mysql = mysql(connection);
@@ -114,7 +114,7 @@ describe('mysql test', function() {
 		mysqlDump({
 			host: 'localhost',
 			user: 'root',
-			password: '',
+			password: 'mRi0oJLzZGWo',
 			database: dbTest,
 			data:false,
 			dest:dest
@@ -136,7 +136,7 @@ describe('mysql test', function() {
 		mysqlDump({
 			host: 'localhost',
 			user: 'root',
-			password: '',
+			password: 'mRi0oJLzZGWo',
 			database: dbTest,
 			schema:false,
 			dest:dest
@@ -158,7 +158,7 @@ describe('mysql test', function() {
 		mysqlDump({
 			host: 'localhost',
 			user: 'root',
-			password: '',
+			password: 'mRi0oJLzZGWo',
 			database: dbTest,
 			where:{
 				players:'id<10 AND gender=1'
@@ -185,7 +185,7 @@ describe('mysql test', function() {
 		mysqlDump({
 			host: 'localhost',
 			user: 'root',
-			password: '',
+			password: 'mRi0oJLzZGWo',
 			database: dbTest,
 			schema:false,
 			getDump:true,
@@ -206,7 +206,7 @@ describe('mysql test', function() {
 		mysqlDump({
 			host: 'localhost',
 			user: 'root',
-			password: '',
+			password: 'mRi0oJLzZGWo',
 			database: dbTest,
 			dest:dest
 		},function(err){
@@ -227,7 +227,7 @@ describe('mysql test', function() {
 		mysqlDump({
 			host: 'localhost',
 			user: 'root',
-			password: '',
+			password: 'mRi0oJLzZGWo',
 			database: dbTest,
 			tables:['players'],
 			ifNotExist:true,
@@ -250,7 +250,7 @@ describe('mysql test', function() {
 		mysqlDump({
 			host: 'localhost',
 			user: 'root',
-			password: '',
+			password: 'mRi0oJLzZGWo',
 			database: dbTest,
 			autoIncrement:false,
 			ifNotExist:true,
@@ -264,15 +264,15 @@ describe('mysql test', function() {
 			done();
 		})
 	});
-	
+
 	it('should create a dump file that ignores foreign key constraints', function(done) {
 		this.timeout(8000);
 		var dest = './data.sql';
-		
+
 		mysqlDump({
 			host: 'localhost',
 			user: 'root',
-			password: '',
+			password: 'mRi0oJLzZGWo',
 			database: dbTest,
 			dest:dest,
 			ignoreKeys: true
@@ -284,16 +284,17 @@ describe('mysql test', function() {
 			expect(file).to.contain("SET FOREIGN_KEY_CHECKS=1");
 			fs.unlinkSync(dest);
 			done();
+        })
 	});
-		
+
 	it('should create a dump file that does not ignore foreign key constraints', function(done) {
 		this.timeout(8000);
 		var dest = './data.sql';
-		
+
 		mysqlDump({
 			host: 'localhost',
 			user: 'root',
-			password: '',
+			password: 'mRi0oJLzZGWo',
 			database: dbTest,
 			dest:dest,
 			ignoreKeys: false
@@ -305,6 +306,6 @@ describe('mysql test', function() {
 			expect(file).to.not.contain("SET FOREIGN_KEY_CHECKS=1");
 			fs.unlinkSync(dest);
 			done();
+        })
 	});
 });
-

--- a/test.js
+++ b/test.js
@@ -264,5 +264,47 @@ describe('mysql test', function() {
 			done();
 		})
 	});
+	
+	it('should create a dump file that ignores foreign key constraints', function(done) {
+		this.timeout(8000);
+		var dest = './data.sql';
+		
+		mysqlDump({
+			host: 'localhost',
+			user: 'root',
+			password: '',
+			database: dbTest,
+			dest:dest,
+			ignoreKeys: true
+		},function(err){
+			var file = String(fs.readFileSync(dest));
+			expect(err).to.be.null;
+			expect(file).not.to.be.null;
+			expect(file).to.contain("SET FOREIGN_KEY_CHECKS=0");
+			expect(file).to.contain("SET FOREIGN_KEY_CHECKS=1");
+			fs.unlinkSync(dest);
+			done();
+	});
+		
+	it('should create a dump file that does not ignore foreign key constraints', function(done) {
+		this.timeout(8000);
+		var dest = './data.sql';
+		
+		mysqlDump({
+			host: 'localhost',
+			user: 'root',
+			password: '',
+			database: dbTest,
+			dest:dest,
+			ignoreKeys: false
+		},function(err){
+			var file = String(fs.readFileSync(dest));
+			expect(err).to.be.null;
+			expect(file).not.to.be.null;
+			expect(file).to.not.contain("SET FOREIGN_KEY_CHECKS=0");
+			expect(file).to.not.contain("SET FOREIGN_KEY_CHECKS=1");
+			fs.unlinkSync(dest);
+			done();
+	});
 });
 


### PR DESCRIPTION
Adds an 'ignoreKeys = true' option to the default options which will disable foreign key constraints for the mysql dump. Foreign key constraints are re-enabled once the import of the dump is completed.

Implemented as dumps that include data may require that tables are restored in a particular order to satisfy foreign key constraints.
